### PR TITLE
Monsters Inc. Scenario

### DIFF
--- a/src/main/java/com/gmail/val59000mc/UhcCore.java
+++ b/src/main/java/com/gmail/val59000mc/UhcCore.java
@@ -21,7 +21,7 @@ public class UhcCore extends JavaPlugin{
 	private static final int MIN_VERSION = 8;
 	private static final int MAX_VERSION = 16;
 
-	private static UhcCore pl;
+	public static UhcCore pl;
 	private static int version;
 	private boolean bStats;
 	private Updater updater;

--- a/src/main/java/com/gmail/val59000mc/scenarios/Scenario.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/Scenario.java
@@ -56,7 +56,8 @@ public enum Scenario{
     FLYHIGH("Fly High", UniversalMaterial.ELYTRA, FlyHighListener.class, 9, "&6Fly High&7:", "&7- Players spawn with a elytra."),
     RANDOMIZEDDROPS("Randomized Drops", UniversalMaterial.EXPERIENCE_BOTTLE, RandomizedDropsListener.class, "&6Randomized Drops&7:", "&7- Every block broken will drop random items." ),
     UPSIDEDOWNCRAFTING("Upside Down Crafting", UniversalMaterial.CRAFTING_TABLE, UpsideDownCraftsListener.class, 13,"&6Upside Down Crafting&7:", "&7- This scenario flips all crafts upside down."),
-    RANDOMIZEDCRAFTS("Randomized Crafts", UniversalMaterial.CRAFTING_TABLE, RandomizedCraftsListener.class, 13,"&6Randomized Crafts&7:", "&7- This scenario randomizes the results of all crafts.");
+    RANDOMIZEDCRAFTS("Randomized Crafts", UniversalMaterial.CRAFTING_TABLE, RandomizedCraftsListener.class, 13,"&6Randomized Crafts&7:", "&7- This scenario randomizes the results of all crafts."),
+    MONSTERSINC("Monsters Inc.", UniversalMaterial.IRON_DOOR, MonstersIncListener.class, "&6Monstersc Inc&7:", "&7- In this scenario all doors are linked as portals.");
 
     private String name;
     private UniversalMaterial material;

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -1,0 +1,85 @@
+package com.gmail.val59000mc.scenarios.scenariolisteners;
+
+import com.gmail.val59000mc.UhcCore;
+import com.gmail.val59000mc.scenarios.ScenarioListener;
+
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Bisected;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.metadata.MetadataValue;
+
+public class MonstersIncListener extends ScenarioListener {
+
+    UhcCore plugin = UhcCore.pl;
+    private int DoorsPlaced;
+    private HashMap<Integer, Location> DoorLocs = new HashMap<>();
+
+    @EventHandler (ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent e) {
+
+        Block block = e.getBlock();
+        Location loc = e.getBlock().getLocation();
+
+        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+            block.setMetadata("DoorNum", new FixedMetadataValue(plugin, DoorsPlaced));
+            DoorLocs.put(DoorsPlaced, loc);
+            DoorsPlaced++;
+        }
+    }
+
+    @EventHandler (ignoreCancelled = true)
+    public void onBlockClick(PlayerInteractEvent e) {
+
+        Action action = e.getAction();
+        Block block = e.getClickedBlock();
+        Player player = e.getPlayer();
+        int doorClicked = -1;
+        int randomDoor;
+
+        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+            Bisected door = (Bisected) block.getBlockData();
+            if (action == Action.RIGHT_CLICK_BLOCK){
+                if (door.getHalf().toString() == "TOP" || door.getHalf().toString() == "UPPER") {
+                    block = block.getRelative(BlockFace.DOWN, 1);
+                }
+                if (block.hasMetadata("DoorNum")) {
+                    List<MetadataValue> values = block.getMetadata("DoorNum");
+                    doorClicked = values.get(0).asInt();
+                }
+                if (DoorsPlaced > 1){
+                    do {
+                        randomDoor = (int) (Math.random() * DoorLocs.size());
+                    } while (randomDoor == doorClicked);
+                    Location gotoloc = DoorLocs.get(randomDoor);
+                    player.teleport(gotoloc.clone().add(0.5, 0, 0.5));
+                }
+            }
+        }
+
+    }
+
+    @EventHandler (ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent e) {
+
+        Block block = e.getBlock();
+
+        if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
+            e.getPlayer().sendMessage("Stop that!");
+            e.setCancelled(true);
+        }
+
+    }
+}

--- a/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
+++ b/src/main/java/com/gmail/val59000mc/scenarios/scenariolisteners/MonstersIncListener.java
@@ -5,10 +5,8 @@ import com.gmail.val59000mc.scenarios.ScenarioListener;
 
 import java.util.List;
 import java.util.HashMap;
-import java.util.Map;
 
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.block.Block;
@@ -51,15 +49,15 @@ public class MonstersIncListener extends ScenarioListener {
 
         if(!block.getType().toString().contains("TRAP") && block.getType().toString().contains("DOOR")) {
             Bisected door = (Bisected) block.getBlockData();
-            if (action == Action.RIGHT_CLICK_BLOCK){
-                if (door.getHalf().toString() == "TOP" || door.getHalf().toString() == "UPPER") {
+            if (action == Action.RIGHT_CLICK_BLOCK) {
+                if (door.getHalf().toString().equals("TOP") || door.getHalf().toString().equals("UPPER")) {
                     block = block.getRelative(BlockFace.DOWN, 1);
                 }
                 if (block.hasMetadata("DoorNum")) {
                     List<MetadataValue> values = block.getMetadata("DoorNum");
                     doorClicked = values.get(0).asInt();
                 }
-                if (DoorsPlaced > 1){
+                if (DoorsPlaced > 1) {
                     do {
                         randomDoor = (int) (Math.random() * DoorLocs.size());
                     } while (randomDoor == doorClicked);

--- a/src/main/java/com/gmail/val59000mc/utils/UniversalMaterial.java
+++ b/src/main/java/com/gmail/val59000mc/utils/UniversalMaterial.java
@@ -91,6 +91,7 @@ public enum UniversalMaterial{
     ELYTRA,
     CRAFTING_TABLE("WORKBENCH", "CRAFTING_TABLE"),
     EXPERIENCE_BOTTLE("EXP_BOTTLE", "EXPERIENCE_BOTTLE"),
+    IRON_DOOR,
 
     // Flowers
     POPPY("RED_ROSE", "POPPY", (short) 0),


### PR DESCRIPTION
# Monsters Inc.
Based on the want to play the "Monsters Inc." scenario my friends and I have seen in youtube UHC series, I tried to recreate it for use with UhcCore.

### What this does: 
When two or more doors are placed, they are added to a list. When a door is interacted with (right click), the player is moved to a door that was placed elsewhere in the world.

### What I haven't accounted for:
1. Doors already generated in the world (Villages)
   * This means that doors in villages can still teleport a player, however they will only be teleported to doors made by themselves or another player.
2. Iron doors
   * Iron doors will still send a player to another door, however they stay shut. This could be changed, but I am not sure it needs to. There might be scenarios where a door a player teleports to and can't open is advantageous for another player.
3. I don't have java experience (or much experience with code in general) so there might be better ways to do the things I was trying to do.

### Considerations
1. Trapdoors can be used as well by removing `!block.getType().toString().contains("TRAP") ` from `MonstersIncListener.java`
2. Adding a cap for doors in the world
3. Adding a cap for doors place by a single player
4. Should players start with doors?
5. Doors are currently unbreakable, but I used a HashMap instead of an ArrayList so that doors could potentially be breakable and removed from the teleport pool.
6. Making those ideas as configurable options

### In closing
Overall, this scenario was fun to create and even more fun to play. I think it could probably be improved in certain areas, but the only big issue I have with it is the description I gave to it in `Scenario.java`, which you can probably improve.